### PR TITLE
Fix brightness initial color

### DIFF
--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -46,8 +46,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
-import kotlin.math.pow
-import kotlin.math.sqrt
+import kotlin.math.max
 
 /**
  * BrightnessSlider allows you to adjust the brightness value of the selected color from color pickers.
@@ -202,11 +201,7 @@ public fun BrightnessSlider(
                 }
                 if (initialColor != null && !isInitialized) {
                     isInitialized = true
-                    val brightness = sqrt(
-                        0.299 * initialColor.red.toDouble().pow(2.0) +
-                            0.587 * initialColor.green.toDouble().pow(2.0) +
-                            0.114 * initialColor.blue.toDouble().pow(2.0)
-                    ).toFloat()
+                    val brightness = max(max(initialColor.red,initialColor.green),initialColor.blue)
                     controller.setBrightness(brightness, fromUser = false)
                 }
             }

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -201,7 +201,7 @@ public fun BrightnessSlider(
                 }
                 if (initialColor != null && !isInitialized) {
                     isInitialized = true
-                    val brightness = max(max(initialColor.red,initialColor.green),initialColor.blue)
+                    val brightness = max(max(initialColor.red, initialColor.green), initialColor.blue)
                     controller.setBrightness(brightness, fromUser = false)
                 }
             }

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/HsvColorPicker.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/HsvColorPicker.kt
@@ -45,7 +45,6 @@ import kotlinx.coroutines.flow.mapNotNull
 import kotlinx.coroutines.launch
 import kotlin.math.cos
 import kotlin.math.sin
-import kotlin.math.sqrt
 
 /**
  * HsvColorPicker allows you to get colors from HSV color palette by tapping on the desired color.
@@ -169,10 +168,8 @@ public fun HsvColorPicker(
             }
             val palette = controller.paletteBitmap
             if (palette != null && initialColor != null && !isInitialized) {
-                val x2 = palette.width * 0.5f
-                val y2 = palette.height * 0.5f
-                val pickerWidth = sqrt((x2 * x2 + y2 * y2)) / 2f
-                if (pickerWidth > 0) {
+                val pickerRadius: Float = palette.width.coerceAtMost(palette.height) * 0.5f
+                if (pickerRadius > 0) {
                     isInitialized = true
                     val hsv = FloatArray(3)
                     android.graphics.Color.RGBToHSV(
@@ -181,16 +178,11 @@ public fun HsvColorPicker(
                         (initialColor.blue * 255).toInt(),
                         hsv
                     )
-                    val colorRadius: Float = hsv[1] * pickerWidth * 2
-                    val angle: Double = ((1 - (hsv[0] / 360f)) * (2 * Math.PI))
-                    val midX: Float = controller.canvasSize.value.width / 2f
-                    val midY: Float = controller.canvasSize.value.height / 2f
-                    val xOffset: Float =
-                        (cos(angle) * colorRadius).toFloat() // offset from the midpoint of the circle
-                    val yOffset: Float = sin(angle).toFloat() * colorRadius
-                    val x = midX + xOffset
-                    val y = midY + yOffset
-                    controller.selectByCoordinate(x, y, false)
+                    val angle = (Math.PI / 180f) * hsv[0]
+                    val saturationVector = pickerRadius * hsv[1]
+                    val x = saturationVector * cos(angle)+center.x
+                    val y = saturationVector * sin(angle)+center.y
+                    controller.selectByCoordinate(x.toFloat(), y.toFloat(), false)
                 }
             }
         }

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/HsvColorPicker.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/HsvColorPicker.kt
@@ -180,8 +180,8 @@ public fun HsvColorPicker(
                     )
                     val angle = (Math.PI / 180f) * hsv[0]
                     val saturationVector = pickerRadius * hsv[1]
-                    val x = saturationVector * cos(angle)+center.x
-                    val y = saturationVector * sin(angle)+center.y
+                    val x = saturationVector * cos(angle) + center.x
+                    val y = saturationVector * sin(angle) + center.y
                     controller.selectByCoordinate(x.toFloat(), y.toFloat(), false)
                 }
             }


### PR DESCRIPTION
### 🎯 Goal
The algorithm that maps the RGB color to (x, y) coordinates did not work correctly in all cases.
Furthermore, the calculation of the brightness slider position was not accurate either.

### 🛠 Implementation details
I didn't change the interface anymore, I just modified the algorithm. The code snippet in issue #9 was incorrect.

### ✍️ Explain examples
I didn't make any changes to any interface
