### PR TITLE
Fix debounce issue

### DIFF
--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
@@ -244,7 +244,11 @@ public class ColorPickerController {
         hsv[2] = brightness
         _selectedColor.value =
             Color(android.graphics.Color.HSVToColor((alpha.value * 255).toInt(), hsv))
-        notifyColorChanged(fromUser)
+        if (fromUser && debounceDuration != 0L) {
+            notifyColorChangedWithDebounce(fromUser)
+        } else {
+            notifyColorChanged(fromUser)
+        }
     }
 
     /** Return a [Color] that is applied with HSV color factors to the [color]. */


### PR DESCRIPTION
### 🎯 Goal
As I described the problem in #26, the debounce time had no effect on the brightness slider

### 🛠 Implementation details
I added it by checking if debounce is turned on

### ✍️ Explain examples
No changes were made to the public interface. The user just needs to enable debounce and it will work as expected.
`controller.setDebounceDuration(200)`