### PR TITLE
Add initialColor to AlphaSlider

### DIFF
--- a/colorpicker-compose/api/colorpicker-compose.api
+++ b/colorpicker-compose/api/colorpicker-compose.api
@@ -1,5 +1,5 @@
 public final class com/github/skydoves/colorpicker/compose/AlphaSliderKt {
-	public static final fun AlphaSlider-VVBY8Eo (Landroidx/compose/ui/Modifier;Lcom/github/skydoves/colorpicker/compose/ColorPickerController;FFJLandroidx/compose/ui/graphics/ImageBitmap;FJFLandroidx/compose/ui/graphics/Paint;JJFLandroidx/compose/runtime/Composer;III)V
+	public static final fun AlphaSlider-I89wPZw (Landroidx/compose/ui/Modifier;Lcom/github/skydoves/colorpicker/compose/ColorPickerController;FFJLandroidx/compose/ui/graphics/ImageBitmap;FJFLandroidx/compose/ui/graphics/Paint;JJFLandroidx/compose/ui/graphics/Color;Landroidx/compose/runtime/Composer;III)V
 }
 
 public final class com/github/skydoves/colorpicker/compose/AlphaTileDrawable : android/graphics/drawable/Drawable {

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
@@ -24,6 +24,10 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.geometry.Offset
@@ -60,6 +64,8 @@ import androidx.compose.ui.unit.dp
  * @param tileOddColor Color of the odd tiles.
  * @param tileEvenColor Color of the even tiles.
  * @param tileSize DP size of tiles.
+ * @param initialColor [Color] of the initial state. This property works for [HsvColorPicker] and
+ * it will be selected on rightmost of slider if you give null value.
  */
 @Composable
 public fun AlphaSlider(
@@ -79,6 +85,7 @@ public fun AlphaSlider(
     tileOddColor: Color = defaultTileOddColor,
     tileEvenColor: Color = defaultTileEvenColor,
     tileSize: Dp = 12.dp,
+    initialColor: Color? = null,
 ) {
     val density = LocalDensity.current
     var backgroundBitmap: ImageBitmap? = null
@@ -91,6 +98,7 @@ public fun AlphaSlider(
     val colorPaint: Paint = Paint().apply {
         color = controller.pureSelectedColor.value
     }
+    var isInitialized by remember { mutableStateOf(false) }
 
     SideEffect {
         controller.isAttachedAlphaSlider = true
@@ -224,6 +232,10 @@ public fun AlphaSlider(
                         Paint(),
                     )
                 }
+            }
+            if (initialColor != null && !isInitialized) {
+                isInitialized = true
+                controller.setAlpha(alpha = initialColor.alpha, fromUser = false)
             }
         }
     }

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -62,7 +62,7 @@ import kotlin.math.max
  * @param wheelColor [Color] of th wheel.
  * @param wheelPaint [Paint] to draw the wheel.
  * @param initialColor [Color] of the initial state. This property works for [HsvColorPicker] and
- * it will be selected on center if you give null value.
+ * it will be selected on rightmost of slider if you give null value.
  */
 @Composable
 public fun BrightnessSlider(


### PR DESCRIPTION
### 🎯 Goal

I have applied the `initialColor` to `AlphaSlider`, just like `HsvColorPicker` and `BrightnessSlider`, allowing you to set the initial alpha value.

### 🛠 Implementation details

I have implemented `initialColor` parameter and `isInitialized` flag in the same format as `HsvColorPicker` and `BrightnessSlider`. 

Additionally, I have updated a portion of the `initialColor` description in `BrightnessSlider`: 
`it will be selected on center if you give null value.` 
➡️ `it will be selected on the rightmost of the slider if you give a null value.`

### ✍️ Explain examples

You can initialize the Color by passing it as the `initialColor` parameter, just like in `HsvColorPicker` and `BrightnessSlider`.

```       
 AlphaSlider(
            modifier = Modifier
                .fillMaxWidth()
                .padding(10.dp)
                .height(35.dp)
                .align(Alignment.CenterHorizontally),
            controller = controller,
            initialColor = Color.Transparent,
        )
```

---
In the process of repeatedly selecting colors through a dialog that includes `AlphaSlider`, I have noticed that the alpha value resets, causing inconvenience. I would like to propose a modification to address this issue. I would like to express my gratitude for using your cool library in my personal project. 👍
