### PR TITLE
Add selectByColor to ColorPickerController

### DIFF
--- a/app/src/main/kotlin/com/github/skydoves/colorpickercomposedemo/screens/HsvColorPickerColoredSelectorScreen.kt
+++ b/app/src/main/kotlin/com/github/skydoves/colorpickercomposedemo/screens/HsvColorPickerColoredSelectorScreen.kt
@@ -17,12 +17,15 @@ package com.github.skydoves.colorpickercomposedemo.screens
 
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material.ExperimentalMaterialApi
+import androidx.compose.material.Surface
 import androidx.compose.material.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -48,6 +51,7 @@ import com.github.skydoves.colorpicker.compose.HsvColorPicker
 import com.github.skydoves.colorpicker.compose.drawColorIndicator
 import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 
+@OptIn(ExperimentalMaterialApi::class)
 @Preview
 @Composable
 @ExperimentalComposeUiApi
@@ -58,6 +62,23 @@ fun HsvColorPickerColoredSelectorScreen() {
 
   Column(modifier = Modifier.semantics { testTagsAsResourceId = true }) {
     Spacer(modifier = Modifier.weight(1f))
+
+    Row(modifier = Modifier.weight(3f)) {
+      listOf(Color.Red, Color.Green, Color.Blue, Color.Yellow, Color.Gray)
+        .forEach { color ->
+          Surface(
+            modifier = Modifier
+              .height(40.dp)
+              .weight(1f)
+              .padding(horizontal = 4.dp),
+            color = color,
+            shape = RoundedCornerShape(6.dp),
+            onClick = {
+              controller.selectByColor(color, true)
+            },
+          ) {}
+        }
+    }
 
     Box(modifier = Modifier.weight(8f)) {
       HsvColorPicker(

--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
@@ -37,6 +37,9 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlin.math.atan2
+import kotlin.math.cos
+import kotlin.math.max
+import kotlin.math.sin
 import kotlin.math.sqrt
 
 /** Creates and remembers a [ColorPickerController] on the current composer. */
@@ -203,6 +206,31 @@ public class ColorPickerController {
         notifyColorChangedWithDebounce(fromUser)
       } else {
         notifyColorChanged(fromUser)
+      }
+    }
+  }
+
+  public fun selectByColor(color: Color, fromUser: Boolean) {
+    val palette = paletteBitmap
+    if (palette != null) {
+      val pickerRadius: Float = palette.width.coerceAtMost(palette.height) * 0.5f
+      if (pickerRadius > 0) {
+        val hsv = FloatArray(3)
+        android.graphics.Color.RGBToHSV(
+          (color.red * 255).toInt(),
+          (color.green * 255).toInt(),
+          (color.blue * 255).toInt(),
+          hsv,
+        )
+        val angle = (Math.PI / 180f) * hsv[0] * (-1)
+        val saturationVector = pickerRadius * hsv[1]
+        val x = saturationVector * cos(angle) + (palette.width / 2)
+        val y = saturationVector * sin(angle) + (palette.height / 2)
+        selectByCoordinate(x.toFloat(), y.toFloat(), fromUser)
+
+        // select brightness
+        val brightness = max(max(color.red, color.green), color.blue)
+        setBrightness(brightness, fromUser = false)
       }
     }
   }


### PR DESCRIPTION
### 🎯 Goal
Currently the `HsvColorPicker` color is only updated by interacting with it. The only way we have to select a specific color without interacting with the picker is by setting an `initialColor`. However, it may be useful to select a color at any time without interacting with the picker.

### 🛠 Implementation details
This PR introduces the `selectByColor(color: Color, fromUser: Boolean)` public method that allows to select a `color` on the picker. `fromUser` enables notifying the color change. This method also updates the brightness. In this case `fromUser` is false to avoid notifying twice.

I added an example on the `HsvColorPickerColoredSelectorScreen`. There's a small palette of colors that can be clicked to select the same color on the picker.

### Screenshot

<img width="300" alt="Screenshot 2023-11-23 at 19 31 53" src="https://github.com/skydoves/colorpicker-compose/assets/148365/0540b44d-2142-42c3-af01-3dafd13b7bdd">

