### PR TITLE
Fix BrightnessSlider transparent background

### DIFF
--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -168,8 +168,8 @@ public fun BrightnessSlider(
         canvas.drawImage(it, Offset.Zero, Paint())
 
         // draw a linear gradient color shader.
-        val startColor = controller.pureSelectedColor.value.copy(alpha = 0f)
-        val endColor = controller.pureSelectedColor.value.copy(alpha = 1f)
+        val startColor = Color.Black
+        val endColor = controller.pureSelectedColor.value
         val shader = LinearGradientShader(
           colors = listOf(startColor, endColor),
           from = Offset.Zero,


### PR DESCRIPTION
After a thorough refactoring of the BrightnessSlider somewhere after release 1.0.4, the slider background would falsely show a gradient going from full transparency to zero transparency:

This commit removes the alpha logic and replaces it with the previously used shader going from pure black to the (pure) selected colour. The previous logic, for reference:

https://github.com/skydoves/colorpicker-compose/blob/0320c677722df315057189c46bf3ac0b4ebdac72/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt#L172-L177

Fixes #42