### PR TITLE
BitmapCalculator: fix use of a recycled bitmap

### DIFF
--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BitmapCalculator.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/BitmapCalculator.kt
@@ -30,12 +30,17 @@ internal object BitmapCalculator {
    * corresponding dimension of the target size.
    */
   internal fun scaleBitmap(bitmap: Bitmap, targetSize: IntSize): Bitmap {
-    return Bitmap.createScaledBitmap(
-      bitmap,
-      targetSize.width,
-      targetSize.height,
-      false,
-    )
+    val sameSize = (targetSize.height == bitmap.height && targetSize.width == bitmap.width)
+    return if (sameSize) {
+      bitmap.copy(bitmap.config, bitmap.isMutable)
+    } else {
+      Bitmap.createScaledBitmap(
+        bitmap,
+        targetSize.width,
+        targetSize.height,
+        false,
+      )
+    }
   }
 
   /**


### PR DESCRIPTION
This commit fixes this warning message, which happens with the HSV color picker:

 "Called getWidth() on a recycle()'d bitmap! This is undefined behavior!"

It is likely due to the fact that createScaledBitmap() will usually return a new bitmap, but will return the source bitmap if the dimensions are the same.

This commit makes sure that scaleBitmap() will always return a new bitmap.
