### PR TITLE
quickfix for occasional color reset to white on recomposition

### DIFF
--- a/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
+++ b/colorpicker-compose/src/main/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
@@ -134,7 +134,11 @@ public class ColorPickerController {
     }
     paletteBitmap = resized.asImageBitmap()
     copiedBitmap.recycle()
-    selectCenter(fromUser = false)
+    if (isHsvColorPalette) {
+      selectByColor(_selectedColor.value, false)
+    } else {
+      selectCenter(fromUser = false)
+    }
     reviseTick.intValue++
   }
 


### PR DESCRIPTION
On rare occasions (was seen using a color picker in an animated widget) the color picker will reset the selected color to white after a recomposition.

This seems to be due to onSizeChanged() being called, even though the color picker did not really change size.

For the HSV color picker it is possible to re-select automatically the previously picked color, since the coordinates can be calculated. For the ImageColorPicker, a more elaborate fix would be needed.
