### PR TITLE
Add support for WasmJs target in addition to exising Js support

### DIFF
--- a/colorpicker-compose/build.gradle.kts
+++ b/colorpicker-compose/build.gradle.kts
@@ -1,4 +1,5 @@
 import com.github.skydoves.colorpicker.compose.Configuration
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
 
 @Suppress("DSL_SCOPE_VIOLATION")
 plugins {
@@ -39,6 +40,11 @@ kotlin {
     browser()
     nodejs()
   }
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs {
+    binaries.library()
+  }
+
   @Suppress("OPT_IN_USAGE")
   applyHierarchyTemplate {
     common {
@@ -61,6 +67,7 @@ kotlin {
             }
           }
           withJs()
+          withWasmJs()
         }
       }
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -56,6 +56,7 @@ kotlin.native.cacheKind=none
 org.jetbrains.compose.experimental.uikit.enabled=true
 org.jetbrains.compose.experimental.macos.enabled=true
 org.jetbrains.compose.experimental.jscanvas.enabled=true
+org.jetbrains.compose.experimental.wasm.enabled=true
 compose.kotlin.native.manageCacheKind=false
 
 # Required to publish to Nexus (see https://github.com/gradle/gradle/issues/11308)

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.2.0"
+agp = "8.4.2"
 dokka = "1.9.10"
 nexusPlugin = "0.29.0"
 kotlin = "2.0.0"

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,5 @@
 [versions]
-agp = "8.4.2"
+agp = "8.2.0"
 dokka = "1.9.10"
 nexusPlugin = "0.29.0"
 kotlin = "2.0.0"

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -6,7 +6,8 @@ pluginManagement {
   }
 }
 dependencyResolutionManagement {
-  repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+  // This causes WASM builds to fail with `Could not determine the dependencies of task ':kotlinNodeJsSetup'.`
+  // repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
   repositories {
     google()
     mavenCentral()
@@ -16,3 +17,4 @@ rootProject.name = "ColorPickerComposeDemo"
 include(":app")
 include(":colorpicker-compose")
 include(":benchmark")
+include("wasmApp")

--- a/wasmApp/build.gradle.kts
+++ b/wasmApp/build.gradle.kts
@@ -1,0 +1,47 @@
+import org.jetbrains.kotlin.gradle.targets.js.dsl.ExperimentalWasmDsl
+import org.jetbrains.kotlin.gradle.targets.js.webpack.KotlinWebpackConfig
+
+@Suppress("DSL_SCOPE_VIOLATION")
+plugins {
+  id(libs.plugins.kotlin.multiplatform.get().pluginId)
+  id(libs.plugins.jetbrains.compose.get().pluginId)
+  id(libs.plugins.compose.compiler.get().pluginId)
+}
+
+kotlin {
+  @OptIn(ExperimentalWasmDsl::class)
+  wasmJs {
+    moduleName = "wasm-demo"
+    browser {
+      commonWebpackConfig {
+        outputFileName = "composeApp.js"
+        devServer = (devServer ?: KotlinWebpackConfig.DevServer()).apply {
+          static = (static ?: mutableListOf()).apply {
+            // Serve sources to debug inside browser
+            add(project.projectDir.path)
+          }
+        }
+      }
+    }
+    binaries.executable()
+  }
+
+  sourceSets {
+    commonMain.dependencies {
+      implementation(compose.runtime)
+      implementation(compose.foundation)
+      implementation(compose.ui)
+      implementation(compose.components.uiToolingPreview)
+      implementation(compose.material)
+      implementation(compose.components.resources)
+
+      implementation(project(":colorpicker-compose"))
+    }
+  }
+}
+
+tasks.withType<org.jetbrains.kotlin.gradle.tasks.KotlinJvmCompile>().configureEach {
+  compilerOptions {
+    jvmTarget.set(org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_11)
+  }
+}

--- a/wasmApp/src/commonMain/kotlin/PickColour.kt
+++ b/wasmApp/src/commonMain/kotlin/PickColour.kt
@@ -1,0 +1,74 @@
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material.Text
+import androidx.compose.runtime.*
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import com.github.skydoves.colorpicker.compose.*
+
+@Composable
+fun PickColour() {
+  val controller = rememberColorPickerController()
+  var currentColorEnvelope by remember {
+    mutableStateOf(
+      ColorEnvelope(
+        Color.Green,
+        "ff00ff00",
+        false
+      )
+    )
+  }
+
+  Column(
+    modifier = Modifier.fillMaxSize().background(Color.Black),
+    horizontalAlignment = Alignment.CenterHorizontally
+  ) {
+    HsvColorPicker(
+      initialColor = currentColorEnvelope.color,
+      modifier = Modifier.padding(10.dp).size(300.dp),
+      controller = controller,
+      onColorChanged = { colorEnvelope: ColorEnvelope ->
+        currentColorEnvelope = colorEnvelope
+      }
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    AlphaSlider(
+      modifier = Modifier
+        .height(35.dp)
+        .width(400.dp),
+      controller = controller,
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    BrightnessSlider(
+      modifier = Modifier
+        .height(35.dp)
+        .width(400.dp),
+      controller = controller,
+    )
+
+    Spacer(Modifier.height(8.dp))
+
+    SelectionContainer {
+      Text(
+        currentColorEnvelope.hexCode,
+        color = currentColorEnvelope.color
+      )
+    }
+
+    AlphaTile(
+      modifier = Modifier
+        .size(80.dp)
+        .clip(RoundedCornerShape(6.dp)),
+      controller = controller
+    )
+  }
+}

--- a/wasmApp/src/commonMain/kotlin/PickColour.kt
+++ b/wasmApp/src/commonMain/kotlin/PickColour.kt
@@ -1,15 +1,45 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.*
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.material.Text
-import androidx.compose.runtime.*
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
-import com.github.skydoves.colorpicker.compose.*
+import com.github.skydoves.colorpicker.compose.AlphaSlider
+import com.github.skydoves.colorpicker.compose.AlphaTile
+import com.github.skydoves.colorpicker.compose.BrightnessSlider
+import com.github.skydoves.colorpicker.compose.ColorEnvelope
+import com.github.skydoves.colorpicker.compose.HsvColorPicker
+import com.github.skydoves.colorpicker.compose.rememberColorPickerController
 
 @Composable
 fun PickColour() {
@@ -19,14 +49,14 @@ fun PickColour() {
       ColorEnvelope(
         Color.Green,
         "ff00ff00",
-        false
-      )
+        false,
+      ),
     )
   }
 
   Column(
     modifier = Modifier.fillMaxSize().background(Color.Black),
-    horizontalAlignment = Alignment.CenterHorizontally
+    horizontalAlignment = Alignment.CenterHorizontally,
   ) {
     HsvColorPicker(
       initialColor = currentColorEnvelope.color,
@@ -34,7 +64,7 @@ fun PickColour() {
       controller = controller,
       onColorChanged = { colorEnvelope: ColorEnvelope ->
         currentColorEnvelope = colorEnvelope
-      }
+      },
     )
 
     Spacer(Modifier.height(8.dp))
@@ -60,7 +90,7 @@ fun PickColour() {
     SelectionContainer {
       Text(
         currentColorEnvelope.hexCode,
-        color = currentColorEnvelope.color
+        color = currentColorEnvelope.color,
       )
     }
 
@@ -68,7 +98,7 @@ fun PickColour() {
       modifier = Modifier
         .size(80.dp)
         .clip(RoundedCornerShape(6.dp)),
-      controller = controller
+      controller = controller,
     )
   }
 }

--- a/wasmApp/src/wasmJsMain/kotlin/Main.kt
+++ b/wasmApp/src/wasmJsMain/kotlin/Main.kt
@@ -1,3 +1,18 @@
+/*
+ * Designed and developed by 2022 skydoves (Jaewoong Eum)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.window.ComposeViewport
 import kotlinx.browser.document

--- a/wasmApp/src/wasmJsMain/kotlin/Main.kt
+++ b/wasmApp/src/wasmJsMain/kotlin/Main.kt
@@ -1,0 +1,10 @@
+import androidx.compose.ui.ExperimentalComposeUiApi
+import androidx.compose.ui.window.ComposeViewport
+import kotlinx.browser.document
+
+@OptIn(ExperimentalComposeUiApi::class)
+fun main() {
+  ComposeViewport(document.body!!) {
+    PickColour()
+  }
+}

--- a/wasmApp/src/wasmJsMain/resources/index.html
+++ b/wasmApp/src/wasmJsMain/resources/index.html
@@ -1,0 +1,12 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Templar Tool</title>
+  <link type="text/css" rel="stylesheet" href="style.css">
+  <script type="application/javascript" src="composeApp.js"></script>
+</head>
+<body>
+</body>
+</html>

--- a/wasmApp/src/wasmJsMain/resources/index.html
+++ b/wasmApp/src/wasmJsMain/resources/index.html
@@ -3,7 +3,7 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Templar Tool</title>
+  <title>WasmJs Color Picker</title>
   <link type="text/css" rel="stylesheet" href="style.css">
   <script type="application/javascript" src="composeApp.js"></script>
 </head>

--- a/wasmApp/src/wasmJsMain/resources/style.css
+++ b/wasmApp/src/wasmJsMain/resources/style.css
@@ -1,0 +1,7 @@
+html, body {
+  width: 100%;
+  height: 100%;
+  margin: 0;
+  padding: 0;
+  overflow: hidden;
+}


### PR DESCRIPTION
### 🎯 Goal
Thank you for a great library! I noticed that you have `js` support but not `wasmJs` support. For our usage we absolutely need `wasmJs` support for all libraries that we use. Adding it is not a big task and since the library is already in a KMP structure it's just some configuration and adding of an example.

### 🛠 Implementation details
Initially I wanted to extend the `app` example by adding a `wasmJs` section and `main` to be able to launch in the browser, but seeing as one of the dependent libraries `io.github.onseok:peekaboo-image-picker` only targets iOS and Android this was not possible. 
Instead I opted for adding a new module called `wasmApp` and did a basic implementation for showing the `HsvColorPicker`, `AlphaSlider`, `BrightnessSlider` and the `AlphaTile`.


One issue that I did pick up while implementing this is the statement`repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)`  in `settings.gradle.kts`. There seems to be a bug here in the KMP plugin when this is enabled along with the `wasmJs` target. I'm unsure why this is needed in the settings, perhaps you can shed some light on the usage of this statement seeing as everything seems to work fine without it. I added a comment to the `settings.gradle.kts` file to make the change apparent. 

### ✍️ Explain examples
I added a new gradle module with a `wasmJs` configuration and setup to test this out. You can test this out by running 
```gradle
$ ./gradlew wasmApp:wasmJsBrowserDevelopmentRun
```

### Preparing a pull request for review
This was done.
> Ensure your change is properly formatted by running:
> 
> ```gradle
> $ ./gradlew spotlessApply
> ```
> 

Also done.
> Please correct any failures before requesting a review.