### PR TITLE
Fix typos and misplaced KDoc across slider components

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ ImageColorPicker(
 )
 ```
 
-With the [modernstorage](https://github.com/google/modernstorage)'s [Photo Picker](https://google.github.io/modernstorage/photopicker/), you can set an desired image as the palette like the below:
+With the [modernstorage](https://github.com/google/modernstorage)'s [Photo Picker](https://google.github.io/modernstorage/photopicker/), you can set a desired image as the palette like the below:
 
 ```kotlin
 val context = LocalContext.current
@@ -255,7 +255,7 @@ AlphaSlider(
 )
 ```
 
-You can customize the border of the sider with the following parameters:
+You can customize the border of the slider with the following parameters:
 
 ```kotlin
 AlphaSlider(
@@ -266,7 +266,7 @@ AlphaSlider(
 )
 ```
 
-You can customize the wheel of the sider with the following parameters:
+You can customize the wheel of the slider with the following parameters:
 
 ```kotlin
 AlphaSlider(
@@ -307,7 +307,7 @@ BrightnessSlider(
 )
 ```
 
-You can customize the wheel of the sider with the following parameters:
+You can customize the wheel of the slider with the following parameters:
 
 ```kotlin
 BrightnessSlider(

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
@@ -35,15 +35,15 @@ import androidx.compose.ui.unit.dp
  * @param borderColor [Color] of the border.
  * @param wheelImageBitmap [ImageBitmap] to draw the wheel.
  * @param wheelRadius Radius of the wheel.
- * @param wheelColor [Color] of th wheel.
+ * @param wheelColor [Color] of the wheel.
  * @param wheelPaint [Paint] to draw the wheel.
  * @param tileOddColor Color of the odd tiles.
  * @param tileEvenColor Color of the even tiles.
  * @param tileSize DP size of tiles.
  * @param initialColor [Color] of the initial state. This property works for [HsvColorPicker] and
+ * it will be selected on rightmost of slider if you give null value.
  * @param onStart Callback invoked when user interaction with the slider starts.
  * @param onFinish Callback invoked when user interaction with the slider ends.
- * it will be selected on rightmost of slider if you give null value.
  */
 @Composable
 public fun AlphaSlider(

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -34,7 +34,7 @@ import androidx.compose.ui.unit.dp
  * @param borderColor [Color] of the border.
  * @param wheelImageBitmap [ImageBitmap] to draw the wheel.
  * @param wheelRadius Radius of the wheel.
- * @param wheelColor [Color] of th wheel.
+ * @param wheelColor [Color] of the wheel.
  * @param wheelPaint [Paint] to draw the wheel.
  * @param initialColor [Color] of the initial state. This property works for [HsvColorPicker] and
  * it will be selected on rightmost of slider if you give null value.

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/PaletteContentScale.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/PaletteContentScale.kt
@@ -25,7 +25,7 @@ public enum class PaletteContentScale {
   FIT,
 
   /**
-   * Crop ths source the corresponding dimension of the target size.
+   * Crop the source the corresponding dimension of the target size.
    * so that if the dimensions (width and height) source is bigger than the target size,
    * it will be cut off from the center.
    */

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/Slider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/Slider.kt
@@ -44,7 +44,7 @@ import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
 
 /**
- * Slider allows you to adjust the a value of the selected color from color pickers.
+ * Slider allows you to adjust the value of the selected color from color pickers.
  * See [AlphaSlider] and [BrightnessSlider] for concrete versions.
  *
  * @param modifier [Modifier] to decorate the internal Canvas.
@@ -54,7 +54,7 @@ import androidx.compose.ui.unit.dp
  * @param borderColor [Color] of the border.
  * @param wheelImageBitmap [ImageBitmap] to draw the wheel.
  * @param wheelRadius Radius of the wheel.
- * @param wheelColor [Color] of th wheel.
+ * @param wheelColor [Color] of the wheel.
  * @param wheelPaint [Paint] to draw the wheel.
  * @param initialColor [Color] of the initial state. This property works for [HsvColorPicker] and
  * it will be selected on rightmost of slider if you give null value.


### PR DESCRIPTION
- Fix 'of th wheel' typo in AlphaSlider, BrightnessSlider, Slider
- Fix stray word in Slider's class-level KDoc
- Fix 'Crop ths source' typo in PaletteContentScale
- Fix 'sider' -> 'slider' typo (x3) in README
- Move misplaced initialColor KDoc sentence in AlphaSlider

### 🎯 Goal
Fix a handful of small typos and a misplaced KDoc line found while reading
through the library source and README. No functional changes - docs/comments only.

### 🛠 Implementation details
- `AlphaSlider.kt`, `BrightnessSlider.kt`, `Slider.kt`: "of th wheel" → "of the wheel"
- `Slider.kt`: class KDoc had a stray "a" ("adjust the a value" → "adjust the value")
- `PaletteContentScale.kt`: "Crop ths source" → "Crop the source"
- `README.md`: "sider" → "slider" (3 occurrences), and "an desired image" → "a desired image"
- `AlphaSlider.kt`: moved a KDoc sentence that had been separated from its
  `@param initialColor` line by unrelated `@param` tags, so it now reads correctly

### ✍️ Explain examples
N/A — text-only fixes, no code behavior changes.