### PR TITLE
Fix stale ColorPickerController API examples in README and docs site

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,11 +134,16 @@ As you can see the above, you can set the palette with the `setPaletteImageBitma
 
 #### PaletteContentScale
 
-You can adjust your palette's image scale with the `setPaletteContentScale` function of the controller as the below:
+You can adjust your palette's image scale with the `paletteContentScale` parameter of `ImageColorPicker` as the below:
 
 ```kotlin
-controller.setPaletteContentScale(PaletteContentScale.FIT) // scale the image to fit width and height.
-controller.setPaletteContentScale(PaletteContentScale.CROP) // center crop the image.
+ImageColorPicker(
+    modifier = Modifier.fillMaxSize(),
+    controller = controller,
+    paletteImageBitmap = ImageBitmap.imageResource(R.drawable.palettebar),
+    paletteContentScale = PaletteContentScale.FIT, // scale the image to fit width and height.
+    // paletteContentScale = PaletteContentScale.CROP, // center crop the image.
+)
 ```
 
 <img src="preview/preview2.gif" width="270" align="right">
@@ -206,10 +211,10 @@ onColorChanged = { envelope ->
 You can customize the wheel with the following functions:
 
 ```kotlin
-.setWheelRadius(40.dp) // set the radius size of the wheel.
-.setWheelColor(Color.Blue) // set the color of the wheel.
-.setWheelAlpha(0.5f) // set the transparency of the wheel.
-.setWheelImageBitmap(imageBitmap) // set the wheel image with your custom ImageBitmap.
+controller.wheelRadius = 40.dp // set the radius size of the wheel.
+controller.wheelColor = Color.Blue // set the color of the wheel.
+controller.wheelAlpha = 0.5f // set the transparency of the wheel.
+controller.wheelBitmap = imageBitmap // set the wheel image with your custom ImageBitmap.
 ```
 
 #### Select Points

--- a/docs/src/wasmJsMain/kotlin/docs/screen/ApiControllerScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/ApiControllerScreen.kt
@@ -127,10 +127,10 @@ fun ApiControllerScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     CodeBlock(
-      code = """controller.setWheelRadius(40.dp)
-controller.setWheelColor(Color.Blue)
-controller.setWheelAlpha(0.5f)
-controller.setWheelImageBitmap(imageBitmap)""",
+      code = """controller.wheelRadius = 40.dp
+controller.wheelColor = Color.Blue
+controller.wheelAlpha = 0.5f
+controller.wheelBitmap = imageBitmap""",
     )
 
     Spacer(modifier = Modifier.height(32.dp))

--- a/docs/src/wasmJsMain/kotlin/docs/screen/ApiImageColorPickerScreen.kt
+++ b/docs/src/wasmJsMain/kotlin/docs/screen/ApiImageColorPickerScreen.kt
@@ -145,11 +145,13 @@ fun ApiImageColorPickerScreen() {
     Spacer(modifier = Modifier.height(16.dp))
 
     CodeBlock(
-      code = """// Scale to fit within bounds
-controller.setPaletteContentScale(PaletteContentScale.FIT)
-
-// Center crop the image
-controller.setPaletteContentScale(PaletteContentScale.CROP)""",
+      code = """ImageColorPicker(
+    modifier = Modifier.fillMaxSize(),
+    controller = controller,
+    paletteImageBitmap = paletteImageBitmap,
+    paletteContentScale = PaletteContentScale.FIT, // scale to fit within bounds
+    // paletteContentScale = PaletteContentScale.CROP, // center crop the image
+)""",
     )
 
     Spacer(modifier = Modifier.height(32.dp))


### PR DESCRIPTION
- README.md: replace removed setWheelRadius/setWheelColor/setWheelAlpha/setWheelImageBitmap calls with direct property assignment (wheelRadius, wheelColor, wheelAlpha, wheelBitmap)
- README.md: replace removed setPaletteContentScale controller method with the paletteContentScale parameter on ImageColorPicker
- docs/ApiControllerScreen.kt: same wheel property fix
- docs/ApiImageColorPickerScreen.kt: same paletteContentScale fix

### 🎯 Goal
`ColorPickerController`'s public API was refactored at some point, the wheel
customization functions (`setWheelRadius`, `setWheelColor`, `setWheelAlpha`,
`setWheelImageBitmap`) became plain properties, and `setPaletteContentScale`
was replaced by a `paletteContentScale` parameter on `ImageColorPicker`. The
README and the documentation website were never updated to match, so
copy-pasting these examples currently fails to compile. This PR brings both
docs surfaces back in sync with the current API.

### 🛠 Implementation details
- `README.md` "Custom Wheel" section: replaced the four `.setWheelXxx(...)`
  calls with direct property assignment on the controller
  (`controller.wheelRadius = ...`, etc.)
- `README.md` "PaletteContentScale" section: replaced
  `controller.setPaletteContentScale(...)` with the `paletteContentScale`
  parameter on the `ImageColorPicker` composable
- `docs/src/wasmJsMain/kotlin/docs/screen/ApiControllerScreen.kt`: applied
  the same wheel property fix to the live docs site's code sample
- `docs/src/wasmJsMain/kotlin/docs/screen/ApiImageColorPickerScreen.kt`:
  applied the same `paletteContentScale` fix to the live docs site's code
  sample

No functional/library code was changed  this PR only touches documentation
(`README.md`) and the docs website's Kotlin/Wasm source (`docs/` module).

### ✍️ Explain examples
Before ((unresolved reference - these methods don't exist on `ColorPickerController`):
```kotlin
controller.setWheelRadius(40.dp)
controller.setWheelColor(Color.Blue)
controller.setWheelAlpha(0.5f)
controller.setWheelImageBitmap(imageBitmap)
```
After:
```kotlin
controller.wheelRadius = 40.dp
controller.wheelColor = Color.Blue
controller.wheelAlpha = 0.5f
controller.wheelBitmap = imageBitmap
```