### PR TITLE
support for sliders dynamic attachment and detachment

### DIFF
--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/AlphaSlider.kt
@@ -16,7 +16,7 @@
 package com.github.skydoves.colorpicker.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -74,8 +74,12 @@ public fun AlphaSlider(
     tileEvenColor,
   )
 
-  SideEffect {
+  DisposableEffect(controller) {
     controller.isAttachedAlphaSlider = true
+
+    onDispose {
+      controller.isAttachedAlphaSlider = false
+    }
   }
 
   Slider(

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/BrightnessSlider.kt
@@ -16,7 +16,7 @@
 package com.github.skydoves.colorpicker.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -58,8 +58,12 @@ public fun BrightnessSlider(
   onStart: () -> Unit = {},
   onFinish: () -> Unit = {},
 ) {
-  SideEffect {
+  DisposableEffect(controller) {
     controller.isAttachedBrightnessSlider = true
+
+    onDispose {
+      controller.isAttachedBrightnessSlider = false
+    }
   }
 
   Slider(

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/ColorPickerController.kt
@@ -155,12 +155,54 @@ constructor(
 
   /** Indicates if the alpha slider has been attached. */
   internal var isAttachedAlphaSlider: Boolean = false
+    set(value) {
+      if (field != value) {
+        field = value
+        if (!value) {
+          alpha.value = 1.0f
+        }
+        recalculateColorDueToAttachmentChange()
+      }
+    }
 
   /** Indicates if the brightness slider has been attached. */
   internal var isAttachedBrightnessSlider: Boolean = false
+    set(value) {
+      if (field != value) {
+        field = value
+        if (!value) {
+          val (_, _, v) = pureSelectedColor.value.toHSV()
+          brightness.value = v
+        }
+        recalculateColorDueToAttachmentChange()
+      }
+    }
 
   /** Whether a SaturationSlider is attached. */
   internal var isAttachedSaturationSlider: Boolean = false
+    set(value) {
+      if (field != value) {
+        field = value
+        if (!value) {
+          val (_, s, _) = pureSelectedColor.value.toHSV()
+          saturation.value = s
+        }
+        recalculateColorDueToAttachmentChange()
+      }
+    }
+
+  /**
+   * Forcibly recalculates the current color when dynamically added
+   * or removing sliders from the composition tree.
+   */
+  private fun recalculateColorDueToAttachmentChange() {
+    if (!enabled) return
+    val newColor = applyHSVFactors(pureSelectedColor.value)
+    if (_selectedColor.value != newColor) {
+      _selectedColor.value = newColor
+      notifyColorChanged(fromUser = false, source = ColorChangeSource.Programmatic)
+    }
+  }
 
   internal var reviseTick = mutableIntStateOf(0)
 

--- a/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/SaturationSlider.kt
+++ b/colorpicker-compose/src/commonMain/kotlin/com/github/skydoves/colorpicker/compose/SaturationSlider.kt
@@ -16,7 +16,7 @@
 package com.github.skydoves.colorpicker.compose
 
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.SideEffect
+import androidx.compose.runtime.DisposableEffect
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ImageBitmap
@@ -60,8 +60,12 @@ public fun SaturationSlider(
   onStart: () -> Unit = {},
   onFinish: () -> Unit = {},
 ) {
-  SideEffect {
+  DisposableEffect(controller) {
     controller.isAttachedSaturationSlider = true
+
+    onDispose {
+      controller.isAttachedSaturationSlider = false
+    }
   }
 
   Slider(


### PR DESCRIPTION
### 🎯 Goal
PR solves the problem of the "zombie state" that occurs when Alpha, Brightness, and Saturation sliders are dynamically added or removed from the component tree. In the current implementation, sliders use SideEffect to notify the controller of their presence. If the slider is removed from the interface, for example, when hiding via a switch, the isAttached flag remains true in the controller forever. Because of this, the controller continues to apply outdated slider values when calculating the color.

### 🛠 Implementation details
As a solution, I replaced SideEffect with DisposableEffect in the sliders components. This ensures that when the component exits the tree, the onDispose block is triggered and the flags are correctly reset to false. Custom setters have been added to the `ColorPickerController` for `isAttached` flags. Now detaching the slider automatically clears the outdated values: the alpha channel returns to 1.0f, and brightness and saturation are synchronized with the current `pureSelectedColor`, after which color recalculation is immediately started.